### PR TITLE
Correct a typo for supervisor.Config

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -17,7 +17,7 @@ import (
 type Config struct {
 	Services              []Service
 	StatusUpdateListeners []func([]StatusUpdate)
-	RestartInternal       time.Duration
+	RestartInterval       time.Duration
 	Clock                 clock.Clock
 	Logger                *zap.Logger
 }
@@ -63,7 +63,7 @@ func (s *Supervisor) Start(ctx context.Context) error {
 	}
 	s.notifyListeners()
 	// monitor running services
-	restartTicker := s.cfg.Clock.NewTicker(s.cfg.RestartInternal)
+	restartTicker := s.cfg.Clock.NewTicker(s.cfg.RestartInterval)
 	restartTickChan := restartTicker.C()
 	ctxDone := ctx.Done()
 	for {

--- a/supervisor_test.go
+++ b/supervisor_test.go
@@ -185,8 +185,8 @@ func newTestFixture(t *testing.T, cfg *Config) (*testFixture, func()) {
 		restartTicker:   mockclock.NewMockTicker(mockCtrl),
 		restartTickChan: make(chan time.Time),
 	}
-	cfg.RestartInternal = time.Second
-	f.clock.EXPECT().NewTicker(cfg.RestartInternal).Return(f.restartTicker)
+	cfg.RestartInterval = time.Second
+	f.clock.EXPECT().NewTicker(cfg.RestartInterval).Return(f.restartTicker)
 	f.clock.EXPECT().Now().Return(time.Unix(0, mockNowNanos)).AnyTimes()
 	f.restartTicker.EXPECT().C().Return(f.restartTickChan)
 	f.restartTicker.EXPECT().Stop()


### PR DESCRIPTION
A field was accidentally named `RestartInternal` instead of `RestartInterval`.