### PR TITLE
Fix nil check for services

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -46,7 +46,7 @@ func New(cfg *Config) *Supervisor {
 	}
 	var id int
 	for _, service := range cfg.Services {
-		if service != nil {
+		if service != nil && !reflect.ValueOf(service).IsNil() {
 			s.supervisedServices = append(s.supervisedServices, &supervisedService{
 				service: service,
 				id:      id,


### PR DESCRIPTION
Nil checks on underlying values of interfaces don't work without
reflection.