### PR TITLE
feat: provide standard logr.Logger to services

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -136,7 +136,7 @@ func (s *Supervisor) start(ctx context.Context, ss *supervisedService) {
 			Time:        s.cfg.Clock.Now(),
 			Status:      StatusRunning,
 		}
-		err := ss.service.Run(ctx)
+		err := ss.service.Run(logr.NewContext(ctx, s.cfg.Logger.WithValues("service", ss.name)))
 		status := StatusStopped
 		if err != nil {
 			status = StatusError


### PR DESCRIPTION
Enables services to use `logr.FromContext` and
`logr.FromContextOrDiscard` for logging via the standard logr interface.
